### PR TITLE
Solaris/SunOS boot fix

### DIFF
--- a/src/board/mister/ss_core.vhd
+++ b/src/board/mister/ss_core.vhd
@@ -304,7 +304,7 @@ BEGIN
       -- 12MB scaler + 2MB CG3/TCX + 2MB ROM
       RAMSIZE    => RAMSIZE,
       FPU_MULTI  => (FPU_MULTI=1),
-      ETHERNET   => false, --true, -- FAKE !
+      ETHERNET   => true, --true, -- FAKE !
       PS2        => true,
       TCX_ACCEL  => (TCX_ACCEL=1),
       SPORT2     => true,

--- a/src/board/mister/ss_core.vhd
+++ b/src/board/mister/ss_core.vhd
@@ -462,7 +462,7 @@ BEGIN
       clk        => sclk,
       reset_na   => reset_na);
   
-  id0_mist<="011" WHEN scsi_conf="011" ELSE "001";
+  id0_mist<="011" WHEN scsi_conf="011" ELSE "000";
   
   ----------------------------------------------------------
   i_scsi_mist2: ENTITY work.scsi_mist


### PR DESCRIPTION
This fixes the booting of the Solaris7 and SunOS images for me.  I believe I'm setting SCSI ID to 000.  After this change, I'm still able to boot NeXT OS as well.