### PR TITLE
Keep the disks mounted when the OS initiates a restart.

### DIFF
--- a/src/board/mister/ss_core.vhd
+++ b/src/board/mister/ss_core.vhd
@@ -220,7 +220,7 @@ ARCHITECTURE rtl OF ss_core IS
   SIGNAL iic3_scl,iic3_sda_i,iic3_sda_o : std_logic;
   
   SIGNAL img0_readonly,img1_readonly,img6_readonly : std_logic;
-  SIGNAL img0_mounted,img1_mounted,img6_mounted : std_logic;
+  SIGNAL img0_mounted,img1_mounted,img6_mounted : std_logic := '0';
   SIGNAL img0_size,img1_size,img6_size : std_logic_vector(63 DOWNTO 0);
   SIGNAL sd0_lba,sd1_lba,sd6_lba : std_logic_vector(31 DOWNTO 0);
   SIGNAL sd0_rd,sd1_rd,sd6_rd,sd0_wr,sd1_wr,sd6_wr : std_logic;
@@ -239,7 +239,9 @@ ARCHITECTURE rtl OF ss_core IS
   
   SIGNAL rtc_delay : std_logic;
   SIGNAL dreset : std_logic;
-  
+  SIGNAL sysreset : std_logic;
+  SIGNAL reboot_pending : std_logic := '0';
+
   SIGNAL down : std_logic;
   
   SIGNAL ddram_s_readdata      : std_logic_vector(63 DOWNTO 0);
@@ -372,6 +374,7 @@ BEGIN
       wback       => wback,
       aow         => aow,
       dreset      => dreset,
+      sysreset    => sysreset,
       sclk        => sclk);
   
   ----------------------------------------------------------
@@ -515,11 +518,6 @@ BEGIN
         img6_size<=img_size;
         img6_readonly<='1';
         img6_mounted<='1';
-      END IF;
-      IF reset_n='0' THEN
-        img0_mounted<='0';
-        img1_mounted<='0';
-        img6_mounted<='0';
       END IF;
       
       ----------------------------------
@@ -914,8 +912,9 @@ BEGIN
           ddram2b_address<="00000000000000000000000000000";
           IF ioctl_download2='1' THEN
             state<=sDOWNLOAD;
-          ELSIF unsigned(ioctl_addr) >= 131072 THEN
+          ELSIF unsigned(ioctl_addr) >= 131072 OR reboot_pending='1' THEN
             state<=sCLR;
+            reboot_pending<='0';
           END IF;
           
         WHEN sCLR =>
@@ -995,8 +994,11 @@ BEGIN
       ioctl_wr2<=ioctl_wr;
       
       ------------------------------
-      IF ureset3='1' AND ureset2='0' THEN
+      IF (ureset3='1' AND ureset2='0') OR sysreset='1' THEN
         state<=sWAIT;
+        IF sysreset='1' THEN
+          reboot_pending<='1';
+        END IF;
       END IF;
       
       ------------------------------

--- a/src/ts/ts_core.vhd
+++ b/src/ts/ts_core.vhd
@@ -162,6 +162,7 @@ ENTITY ts_core IS
     kbm_layout  : IN  uv8;
     
     dreset      : OUT std_logic;
+    sysreset    : OUT std_logic;
     
     -- Horloge
     sclk        : IN  std_logic
@@ -350,6 +351,7 @@ ARCHITECTURE rtl OF ts_core IS
       IOMMU_VER   : uv8);
     PORT (
       led         : OUT std_logic;
+      sysreset    : OUT std_logic;
       ps2_i       : IN  uv4;
       ps2_o       : OUT uv4;
       sync_rs     : IN  std_logic;
@@ -1336,6 +1338,7 @@ BEGIN
       IOMMU_VER  => IOMMU_VER)
     PORT MAP (
       led         => led_io,
+      sysreset    => sysreset,
       ps2_i       => ps2_i,
       ps2_o       => ps2_o,
       sync_rs     => sync_rs,

--- a/src/ts/ts_io.vhd
+++ b/src/ts/ts_io.vhd
@@ -40,6 +40,7 @@ ENTITY ts_io IS
   PORT (
     -- Ports série
     led         : OUT std_logic;
+    sysreset    : OUT std_logic;
     ps2_i       : IN  uv4;
     ps2_o       : OUT uv4;
     sync_rs     : IN  std_logic;
@@ -216,6 +217,8 @@ ARCHITECTURE rtl OF ts_io IS
 --------------------------------------------------------------------------------
   
 BEGIN
+
+  sysreset <= io_w.req AND io_w.wr AND sel.syscon AND io_w.dw(0);
 
   -----------------------------------
   -- Décodage d'adresses


### PR DESCRIPTION
Keep the disks mounted when the OS initiates a restart. Needs OpenBIOS changes as well for the restart to function. These are in PR: https://github.com/Grabulosaure/ss_openbios/pull/1